### PR TITLE
Add ceph-mon test case

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,4 @@
 manage_packages: true
 non_root_user: gremlin
 non_root_group: gremlin
+ceph_mon_down_num: 1

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,3 @@
 manage_packages: true
 non_root_user: gremlin
 non_root_group: gremlin
-ceph_mon_down_num: 1

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -1,3 +1,4 @@
+localhost
 # High level host groups
 [control]
 [network]

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -2,7 +2,11 @@
 [control]
 [network]
 [compute]
-[storage]
+
+[storage:children]
+mon
+osd
+rgw
 
 
 # Seperated hosts
@@ -11,4 +15,10 @@
 [mq]
 [mc]
 [lb]
+
+# for storage role
 [mon]
+
+[osd]
+
+[rgw]

--- a/playbooks/drill_storage.yaml
+++ b/playbooks/drill_storage.yaml
@@ -1,30 +1,43 @@
-- name: Create local working dir
-  hosts: localhost
-  roles:
-    - provision/local
-  tags:
-    - provision
-
-- name: Random select a storage host
+- name: Preparing for storage node test
   hosts: localhost
   connection: local
   gather_facts: false
   tasks:
-    - set_fact:
-        random_host: "{{ groups['storage'] | random }}"
-        random_mon_host: "{{ groups['mon'] | shuffle }}"
-  tags:
-    - always
+    - name: Random select a storage host
+      add_host:
+        groups: random_storage_host
+        name: "{{ groups['storage'] | random }}"
+      tags:
+        - storage-cpu
 
-- name: Run fault drills on storage nodes in the system level
-  hosts: "{{ hostvars['localhost']['random_host'] }}"
+    - pause:
+        prompt: "Please input the number of ceph-mon will be killed:"
+      register: input_ceph_mon_down_num
+      tags:
+        - ceph-mon
+
+    - name: Random select some monitor nodes
+      add_host:
+        groups: random_mon_group
+        name: "{{ item }}"
+      vars:
+        - shuffle_mon_hosts: "{{ groups['mon'] | shuffle }}"
+          ceph_mon_down_num: "{{ input_ceph_mon_down_num.user_input|int }}"
+      with_items:
+        - "{{ shuffle_mon_hosts[:ceph_mon_down_num|int] }}"
+      tags:
+        - ceph-mon
+
+- name: "CASE: Storage - CPU Press"
+  hosts: random_storage_host
   roles:
     - storage/system
   tags:
-    - storage-system
+    - storage-cpu
 
-- name: Run fault drills on ceph-mon nodes in the service level
-  hosts: "{{ hostvars['localhost']['random_mon_host'][:ceph_mon_down_num] }}"
+- name: "CASE: Storage - Ceph monitor DOWN"
+  hosts: random_mon_group
+  gather_facts: true
   tasks:
     - include_role:
         name: storage/service

--- a/playbooks/drill_storage.yaml
+++ b/playbooks/drill_storage.yaml
@@ -12,8 +12,22 @@
   tasks:
     - set_fact:
         random_host: "{{ groups['storage'] | random }}"
+        random_mon_host: "{{ groups['mon'] | shuffle }}"
+  tags:
+    - always
 
 - name: Run fault drills on storage nodes in the system level
   hosts: "{{ hostvars['localhost']['random_host'] }}"
   roles:
     - storage/system
+  tags:
+    - storage-system
+
+- name: Run fault drills on ceph-mon nodes in the service level
+  hosts: "{{ hostvars['localhost']['random_mon_host'][:ceph_mon_down_num] }}"
+  tasks:
+    - include_role:
+        name: storage/service
+        tasks_from: ceph-mon
+  tags:
+    - ceph-mon

--- a/playbooks/drill_storage.yaml
+++ b/playbooks/drill_storage.yaml
@@ -13,23 +13,7 @@
     - set_fact:
         random_host: "{{ groups['storage'] | random }}"
 
-- name: Create non root user on storage nodes
-  hosts: "{{ hostvars['localhost']['random_host'] }}"
-  roles:
-    - provision/user
-  tags:
-    - provision
-
 - name: Run fault drills on storage nodes in the system level
   hosts: "{{ hostvars['localhost']['random_host'] }}"
   roles:
     - storage/system
-
-# Finally, we conditionally remove basic setup (users,
-# groups, directories)to start from scratch
-- name: Tear down non-root user on storage hosts
-  hosts: "{{ hostvars['localhost']['random_host'] }}"
-  roles:
-    - provision/teardown
-  tags:
-    - teardown-provision

--- a/roles/storage/service/defaults/main.yml
+++ b/roles/storage/service/defaults/main.yml
@@ -1,0 +1,1 @@
+ceph_mon_downtime: 300

--- a/roles/storage/service/tasks/ceph-mon.yml
+++ b/roles/storage/service/tasks/ceph-mon.yml
@@ -1,0 +1,23 @@
+- name: pkill Ceph monitor daemon
+  command: "pkill ceph-mon"
+  become: true
+
+- block:
+   - shell: "ps -ef | grep ceph-mon"
+     register: ps_result
+
+   - fail:
+       msg: "Failed to kill Ceph monitor daemon"
+     when: "'/usr/bin/ceph-mon' in ps_result.stdout"
+
+- pause:
+    seconds: "{{ ceph_mon_downtime }}"
+
+- block:
+   - shell: "/etc/init.d/ceph start mon"
+     become: true
+  rescue:
+   - service:
+       name: "ceph-mon@{{ ansible_hostname }}"
+       state: started
+     become: true


### PR DESCRIPTION
1) pkill Ceph monitor daemon and recover it.
2) use variable `ceph_mon_down_num` to decide the number of ceph-mon
will be killed. It's default to 1, only a ceph-mon will be dead.

@hackerain , please review it.